### PR TITLE
global exception 처리, 예외 처리 추가, 예외 코드 추가, test 코드 mock 객체 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ bin/
 
 ### IntelliJ IDEA ###
 /src/main/resources/application-aws.properties
+/src/main/resources/application-aws-backup.properties
 
 .idea
 *.iws
@@ -37,4 +38,3 @@ out/
 
 ### VS Code ###
 .vscode/
-/src/main/resources/application-aws-backup.properties

--- a/src/main/java/com/musubi/teammusubi/common/exception/ExceptionType.java
+++ b/src/main/java/com/musubi/teammusubi/common/exception/ExceptionType.java
@@ -31,8 +31,9 @@ public enum ExceptionType {
     EXCEEDS_MAXIMUM_STORE_LIMIT("S102", "가게는 최대 3개까지만 운영할 수 없습니다", HttpStatus.BAD_REQUEST),
     NOT_OWNER_OF_STORE("S103", "해당 가게의 주인이 아닙니다.", HttpStatus.UNAUTHORIZED),
     NOT_A_MENU_OF_STORE("S104", "해당 가게의 메뉴가 아닙니다.", HttpStatus.BAD_REQUEST),
+    NOT_A_DELIVERY_OF_STORE("S106", "해당 가게의 주문이 아닙니다.", HttpStatus.BAD_REQUEST),
     STORE_NOT_FOUND_OR_STORE_CLOSE("S105", "선택한 가게가 존재하지 않거나, 폐업상태입니다.", HttpStatus.NOT_FOUND),
-    CATEGORY_NOT_FOUND("S201","잘못 된 가게 카테고리입니다.", HttpStatus.BAD_REQUEST),
+    CATEGORY_NOT_FOUND("S201","잘못된 가게 카테고리입니다.", HttpStatus.BAD_REQUEST),
 
     // 주문(D)
     COMPLETED_DELIVERY_NOT_FOUND("D001", "배달 완료 상태 주문이 존재하지 않습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/musubi/teammusubi/domain/seller/controller/SellerStoreController.java
+++ b/src/main/java/com/musubi/teammusubi/domain/seller/controller/SellerStoreController.java
@@ -76,8 +76,9 @@ public class SellerStoreController {
             @RequestParam(required = false, value = "orderBy", defaultValue = "createdAt") String criteria,
             @RequestParam(required = false, value = "sort", defaultValue = "DESC") String sort
     ) {
+        Long memberId = memberDetails.getMember().getId();
         Page<DeliveryResponse> responses = sellerDeliveryService.retrieveDeliveryByStoreIdAsPageSize(
-                storeId, deliveryStatus, page, size, criteria, sort);
+                memberId, storeId, deliveryStatus, page, size, criteria, sort);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(responses);

--- a/src/main/java/com/musubi/teammusubi/domain/seller/service/SellerMenuService.java
+++ b/src/main/java/com/musubi/teammusubi/domain/seller/service/SellerMenuService.java
@@ -2,6 +2,7 @@ package com.musubi.teammusubi.domain.seller.service;
 
 import com.musubi.teammusubi.common.entity.Menu;
 import com.musubi.teammusubi.common.entity.Store;
+import com.musubi.teammusubi.common.exception.ResponseException;
 import com.musubi.teammusubi.domain.member.repository.MemberRepository;
 import com.musubi.teammusubi.domain.seller.dto.MenuRequest;
 import com.musubi.teammusubi.domain.seller.dto.MenuResponse;
@@ -10,6 +11,8 @@ import com.musubi.teammusubi.domain.seller.repository.SellerStoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.musubi.teammusubi.common.exception.ExceptionType.*;
 
 @Service
 @RequiredArgsConstructor
@@ -20,11 +23,13 @@ public class SellerMenuService {
 
     public MenuResponse createMenu(Long memberId, Long storeId, MenuRequest requestDto) {
         memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다."));
+                .orElseThrow(() -> new ResponseException(USER_NOT_FOUND));
         Store store = sellerStoreRepository.findById(storeId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 가게가 존재하지 않습니다."));
+                .orElseThrow(() -> new ResponseException(STORE_NOT_FOUND));
+
         if(!memberId.equals(store.getMemberId())) {
-            throw new IllegalArgumentException("해당 가게의 주인이 아닙니다.");
+            throw new ResponseException(NOT_OWNER_OF_STORE);
+
         }
         Menu savedMenu = sellerMenuRepository.save(Menu.of(requestDto, store));
 
@@ -34,17 +39,17 @@ public class SellerMenuService {
     @Transactional
     public MenuResponse modifyMenu(Long memberId, Long storeId, Long menuId, MenuRequest requestDto) {
         memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다."));
+                .orElseThrow(() -> new ResponseException(USER_NOT_FOUND));
         sellerStoreRepository.findById(storeId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 가게가 존재하지 않습니다."));
+                .orElseThrow(() -> new ResponseException(STORE_NOT_FOUND));
         Menu menu = sellerMenuRepository.findById(menuId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 메뉴가 존재하지 않습니다."));
+                .orElseThrow(() -> new ResponseException(MENU_NOT_FOUND));
 
         if(!memberId.equals(menu.getStore().getMemberId())) {
-            throw new IllegalArgumentException("해당 가게의 주인이 아닙니다.");
+            throw new ResponseException(NOT_OWNER_OF_STORE);
         }
         if(!storeId.equals(menu.getStore().getId())) {
-            throw new IllegalArgumentException("해당 가게의 메뉴가 아닙니다.");
+            throw new ResponseException(NOT_A_MENU_OF_STORE);
         }
 
         menu.modify(requestDto.getName(), requestDto.getPrice(), requestDto.getDescription());
@@ -54,18 +59,17 @@ public class SellerMenuService {
     @Transactional
     public MenuResponse closeMenu(Long memberId, Long storeId, Long menuId) {
         memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 사용자가 존재하지 않습니다."));
-
+                .orElseThrow(() -> new ResponseException(USER_NOT_FOUND));
         sellerStoreRepository.findById(storeId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 가게가 존재하지 않습니다."));
+                .orElseThrow(() -> new ResponseException(STORE_NOT_FOUND));
         Menu menu = sellerMenuRepository.findById(menuId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 메뉴가 존재하지 않습니다."));
+                .orElseThrow(() -> new ResponseException(MENU_NOT_FOUND));
 
         if(!memberId.equals(menu.getStore().getMemberId())) {
-            throw new IllegalArgumentException("해당 가게의 주인이 아닙니다.");
+            throw new ResponseException(NOT_OWNER_OF_STORE);
         }
         if(!storeId.equals(menu.getStore().getId())) {
-            throw new IllegalArgumentException("해당 가게의 메뉴가 아닙니다.");
+            throw new ResponseException(NOT_A_MENU_OF_STORE);
         }
 
         menu.close();

--- a/src/test/java/com/musubi/teammusubi/seller/SellerDeliveryServiceTest.java
+++ b/src/test/java/com/musubi/teammusubi/seller/SellerDeliveryServiceTest.java
@@ -2,18 +2,13 @@ package com.musubi.teammusubi.seller;
 
 import com.musubi.teammusubi.common.entity.Delivery;
 import com.musubi.teammusubi.common.entity.Member;
-import com.musubi.teammusubi.common.entity.Menu;
 import com.musubi.teammusubi.common.entity.Store;
 import com.musubi.teammusubi.common.enums.DeliveryStatus;
-import com.musubi.teammusubi.common.enums.MenuStatus;
 import com.musubi.teammusubi.domain.member.repository.MemberRepository;
 import com.musubi.teammusubi.domain.seller.dto.DeliveryResponse;
-import com.musubi.teammusubi.domain.seller.dto.MenuRequest;
-import com.musubi.teammusubi.domain.seller.dto.MenuResponse;
 import com.musubi.teammusubi.domain.seller.repository.SellerDeliveryRepository;
 import com.musubi.teammusubi.domain.seller.repository.SellerStoreRepository;
 import com.musubi.teammusubi.domain.seller.service.SellerDeliveryService;
-import com.musubi.teammusubi.domain.seller.service.SellerMenuService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,7 +26,6 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class SellerDeliveryServiceTest {

--- a/src/test/java/com/musubi/teammusubi/seller/SellerDeliveryServiceTest.java
+++ b/src/test/java/com/musubi/teammusubi/seller/SellerDeliveryServiceTest.java
@@ -52,6 +52,7 @@ public class SellerDeliveryServiceTest {
     @DisplayName("사업자 가게별 주문 조회 - 성공")
     void deliveryRetrieveTest() throws Exception {
         // given
+        Long memberId = 1L;
         Long storeId = 1L;
         DeliveryStatus deliveryStatus = DeliveryStatus.PENDING;
         int page = 1;
@@ -59,12 +60,15 @@ public class SellerDeliveryServiceTest {
         String criteria = "createdAt";
         String sort = "DESC";
 
+        Member mockMember = new Member();
         Store mockStore = new Store();
+        mockStore.setMemberId(memberId);
         Delivery mockDelivery1 = new Delivery();
         Delivery mockDelivery2 = new Delivery();
         List<Delivery> deliveryList = Arrays.asList(mockDelivery1, mockDelivery2);
         Page<Delivery> deliveryPage = new PageImpl<>(deliveryList);
 
+        given(memberRepository.findById(memberId)).willReturn(Optional.of(mockMember));
         given(sellerStoreRepository.findById(storeId)).willReturn(Optional.of(mockStore));
         given(sellerDeliveryRepository
                 .findByStoreIdAndStatus(any(Long.class), any(DeliveryStatus.class), any(Pageable.class)))
@@ -73,7 +77,7 @@ public class SellerDeliveryServiceTest {
         // when
         Page<DeliveryResponse> responses
                 = sellerDeliveryService.retrieveDeliveryByStoreIdAsPageSize(
-                        storeId, deliveryStatus, page, size, criteria, sort);
+                        memberId, storeId, deliveryStatus, page, size, criteria, sort);
 
         // then
         assertEquals(2, responses.getTotalElements());
@@ -92,6 +96,7 @@ public class SellerDeliveryServiceTest {
 
         Member mockMember = new Member();
         Store mockStore = new Store();
+        mockStore.setMemberId(memberId);
         Delivery mockDelivery = new Delivery();
         mockDelivery.setStoreId(storeId);
 


### PR DESCRIPTION
- global exception 처리

- 예외 처리 로직 추가
SellerDeliveryService에서 retrieveDeliveryByStoreIdAsPageSize 메서드의 예외 처리 추가

- 예외 코드 추가
NOT_A_DELIVERY_OF_STORE("S106", "해당 가게의 주문이 아닙니다.", HttpStatus.BAD_REQUEST)

- test 코드 mock 객체 설정 추가

- 코드 및 주석 정리